### PR TITLE
add node types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,12 @@
         "@types/jasmine": "*"
       }
     },
+    "@types/node": {
+      "version": "14.0.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.26.tgz",
+      "integrity": "sha512-W+fpe5s91FBGE0pEa0lnqGLL4USgpLgs4nokw16SrBBco/gQxuua7KnArSEOd5iaMqbbSHV10vUDkJYJJqpXKA==",
+      "dev": true
+    },
     "@types/q": {
       "version": "0.0.32",
       "resolved": "http://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@types/isomorphic-fetch": "0.0.34",
     "@types/jasminewd2": "^2.0.4",
+    "@types/node": "^14.0.26",
     "jasmine-awesome-report": "0.0.3",
     "jasmine-spec-reporter": "^4.2.1",
     "tslint": "^5.11.0",


### PR DESCRIPTION
El ci no está fallando debido a un problema al detectar algunos paquetes como inexistentes. Este es un ejemplo de uno de los builds: `https://travis-ci.org/github/AgileTestingColombia/workshop-protractor/builds/711807475`

El output del CI es algo como esto:

```bash
> tsc
node_modules/blocking-proxy/built/lib/blockingproxy.d.ts(1,23): error TS2688: Cannot find type definition file for 'node'.
node_modules/blocking-proxy/built/lib/blockingproxy.d.ts(2,23): error TS2307: Cannot find module 'http'.
node_modules/blocking-proxy/built/lib/webdriver_commands.d.ts(1,23): error TS2688: Cannot find type definition file for 'node'.
node_modules/blocking-proxy/built/lib/webdriver_commands.d.ts(5,25): error TS2307: Cannot find module 'events'.
node_modules/blocking-proxy/built/lib/webdriver_logger.d.ts(1,23): error TS2688: Cannot find type definition file for 'node'.
node_modules/blocking-proxy/built/lib/webdriver_logger.d.ts(2,25): error TS2307: Cannot find module 'stream'.
node_modules/blocking-proxy/built/lib/webdriver_proxy.d.ts(1,23): error TS2688: Cannot find type definition file for 'node'.
node_modules/blocking-proxy/built/lib/webdriver_proxy.d.ts(2,23): error TS2307: Cannot find module 'http'.
node_modules/protractor/built/runner.d.ts(1,23): error TS2688: Cannot find type definition file for 'node'.
node_modules/protractor/built/runner.d.ts(3,30): error TS2307: Cannot find module 'events'.
protractor/helpers/reporter.ts(2,27): error TS2580: Cannot find name 'require'. Do you need to install type definitions for node? Try `npm i @types/node`.
protractor/saucelabs.config.ts(36,14): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i @types/node`.
protractor/saucelabs.config.ts(37,13): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i @types/node`.
protractor/zalenium.config.ts(36,14): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i @types/node`.
protractor/zalenium.config.ts(37,13): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i @types/node`.
src/page/personal-information.page.ts(2,25): error TS2307: Cannot find module 'path'.
src/page/personal-information.page.ts(3,28): error TS2307: Cannot find module 'fs'.
src/page/personal-information.page.ts(78,30): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i @types/node`.
src/service/download.service.ts(1,68): error TS2307: Cannot find module 'fs'.
src/service/download.service.ts(2,25): error TS2307: Cannot find module 'path'.
src/service/download.service.ts(9,31): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i @types/node`.
src/service/download.service.ts(21,46): error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i @types/node`.
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! psl-workshop-protractor@1.0.0 build: `tsc`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the psl-workshop-protractor@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2020-07-25T21_07_58_687Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! psl-workshop-protractor@1.0.0 test:saucelabs: `npm run build && protractor dist/protractor/saucelabs.config.js`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the psl-workshop-protractor@1.0.0 test:saucelabs script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2020-07-25T21_07_58_717Z-debug.log
npm ERR! Test failed.  See above for more details.
The command "npm test" exited with 1.
```